### PR TITLE
Use SPDX identifier as the license in opam

### DIFF
--- a/opam
+++ b/opam
@@ -6,7 +6,7 @@ doc: "https://ocaml.github.io/uchar/"
 dev-repo: "https://github.com/ocaml/uchar.git"
 bug-reports: "https://github.com/ocaml/uchar/issues"
 tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
-license: "typeof OCaml system"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 available: [ ocaml-version >= "3.12.0" ]
 depends: [ "ocamlbuild" {build} ]
 build:


### PR DESCRIPTION
I believe this matches the license in https://github.com/ocaml/uchar/blob/master/LICENSE

This makes the license more obvious for people who are not familiar with the OCaml license